### PR TITLE
bump: activerecord to version 7.0.3 and cockroachdb activerecord adapter to version 7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "pg"
-gem 'activerecord', '~>6.1.0'
+gem 'activerecord', '~>7.0.3'
 # CockroachDB ActiveRecord adapter dependency
-gem 'activerecord-cockroachdb-adapter', '~> 6.1.0'
+gem 'activerecord-cockroachdb-adapter', '~> 7.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3)
-      activesupport (= 6.1.3)
-    activerecord (6.1.3)
-      activemodel (= 6.1.3)
-      activesupport (= 6.1.3)
-    activerecord-cockroachdb-adapter (6.1.8)
-      activerecord (~> 6.1)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activerecord-cockroachdb-adapter (7.0.0)
+      activerecord (~> 7.0.3)
       pg (~> 1.2)
       rgeo-activerecord (~> 7.0.0)
-    activesupport (6.1.3)
+    activesupport (7.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    concurrent-ruby (1.1.8)
-    i18n (1.8.9)
+    concurrent-ruby (1.1.10)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.4)
+    minitest (5.16.3)
     pg (1.2.3)
     rgeo (2.4.0)
     rgeo-activerecord (7.0.1)
       activerecord (>= 5.0)
       rgeo (>= 1.0.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES
-  activerecord (~> 6.1.0)
-  activerecord-cockroachdb-adapter (~> 6.1.0)
+  activerecord (~> 7.0.3)
+  activerecord-cockroachdb-adapter (~> 7.0.0)
   pg
 
 BUNDLED WITH


### PR DESCRIPTION
Since we now support active record 7, we should update the example application we have to use the new version.